### PR TITLE
Fix email sender and CPU alert formatting

### DIFF
--- a/integrations/send_email.py
+++ b/integrations/send_email.py
@@ -2,9 +2,10 @@ import logging
 import smtplib
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
-import aiosmtplib
 
-async def send_email(config, subject, message):
+
+def send_email(config, subject, message):
+    """Send an email alert synchronously using smtplib."""
     try:
         msg = MIMEMultipart()
         msg['From'] = 'monitor@yourdomain.com'
@@ -12,16 +13,17 @@ async def send_email(config, subject, message):
         msg['Subject'] = subject
 
         msg.attach(MIMEText(message, 'plain'))
-        
+
         smtp_server = config.get('EmailConfig', 'SMTPServer')
         smtp_port = config.getint('EmailConfig', 'SMTPPort')
-        smtp_username = config.get('EmailConfig', 'SMTPUsername')
-        smtp_password = config.get('EmailConfig', 'SMTPPassword')
+        smtp_username = config.get('EmailConfig', 'SMTPUsername', fallback='')
+        smtp_password = config.get('EmailConfig', 'SMTPPassword', fallback='')
 
-        async with aiosmtplib.SMTP(smtp_server, smtp_port) as server:
-            await server.login(smtp_username, smtp_password)
-            await server.send_message(msg)
-        
+        with smtplib.SMTP(smtp_server, smtp_port, timeout=10) as server:
+            if smtp_username and smtp_password:
+                server.login(smtp_username, smtp_password)
+            server.send_message(msg)
+
         logging.info(f"Alert email sent: {subject}")
     except Exception as e:
         logging.error(f"Failed to send alert email: {str(e)}")

--- a/main.py
+++ b/main.py
@@ -327,7 +327,7 @@ def monitor_high_cpu_memory(config, disable_slack, print_to_terminal):
                 report_to_admin(
                     config, 
                     "Sustained High CPU Usage Alert", 
-                    f"Total CPU usage has been above {cpu_threshold}% for over {cpu_alert_frequency.total_hours()} hours. Current usage: {total_cpu_usage:.2f}%",
+                    f"Total CPU usage has been above {cpu_threshold}% for over {cpu_alert_frequency.total_seconds() / 3600:.1f} hours. Current usage: {total_cpu_usage:.2f}%",
                     disable_slack, 
                     print_to_terminal
                 )
@@ -528,55 +528,3 @@ if __name__ == "__main__":
             print(f"Failed to start monitoring service: {str(e)}")
         exit(1)
 
-def monitor_journal_events(config, interval_minutes, disable_slack, print_to_terminal):
-    logger.debug("Starting journal event monitoring")
-    if not config.getboolean('Monitoring', 'EnableJournalMonitoring'):
-        logger.debug("Journal monitoring disabled in config")
-        return
-
-    # Load filters from config
-    filters = {
-        key.replace('.filters', ''): {
-            'title': config['JournalMonitoring'].get(f'{key.replace(".filters", "")}.title', key),
-            'filter': config['JournalMonitoring'][key]
-        }
-        for key in config['JournalMonitoring']
-        if key.endswith('.filters')
-    }
-    
-    logger.debug(f"Loaded filters: {list(filters.keys())}")
-
-    try:
-        journal_reader = JournalReader()
-        journal_reader.open(JournalOpenMode.SYSTEM)
-        
-        interval_ago = datetime.now(tz=pytz.UTC) - timedelta(minutes=interval_minutes)
-        cutoff_usec = int(interval_ago.timestamp() * 1_000_000)
-        journal_reader.seek_realtime_usec(cutoff_usec)
-        
-        for record in journal_reader:
-            entry_usec = record.get_realtime_usec()
-            if entry_usec < cutoff_usec:
-                continue
-
-            if 'MESSAGE' in record.data:
-                message = record.data['MESSAGE']
-                timestamp = datetime.fromtimestamp(entry_usec / 1_000_000).strftime("%Y-%m-%d %H:%M:%S %Z")
-                process_name = record.data.get('SYSLOG_IDENTIFIER', record.data.get('_COMM', 'unknown'))
-                
-                # Test message against each filter
-                for event_name, filter_data in filters.items():
-                    matches = {}
-                    if evaluate_filter_with_sympy(filter_data['filter'], message, matches=matches):
-                        formatted_message = f"[{timestamp}] [{process_name}] {message}"
-                        report_to_admin(
-                            config,
-                            f"Journal Event: {filter_data['title']}", 
-                            formatted_message,
-                            disable_slack,
-                            print_to_terminal
-                        )
-                        break
-
-    except Exception as e:
-        logger.error(f"Error monitoring journal events: {str(e)}", exc_info=True)


### PR DESCRIPTION
## Summary
- send alert emails using blocking `smtplib` to avoid unawaited coroutine
- show CPU alert duration in hours using `total_seconds`
- drop duplicate definition of `monitor_journal_events`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sympy')*

------
https://chatgpt.com/codex/tasks/task_e_6840587a8e10832aaafb99c9658ba553